### PR TITLE
relocated __init__.py and modified its content to make a local import…

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-from spiops import *

--- a/spiops/__init__.py
+++ b/spiops/__init__.py
@@ -1,0 +1,1 @@
+from .spiops import *


### PR DESCRIPTION
… of the underlaying spiops.py module

I was testing some methods I found in spiops and realized pip install was not installing anything because spiops was missing an __init__.py.

Not sure it is still relevant... but anyway...

Also slightly modified the __init__.py content. Be sure to check also if this was the intended behavior.

Best
